### PR TITLE
exe.go: ignore sections containing uninitialized data when computing …

### DIFF
--- a/exe.go
+++ b/exe.go
@@ -346,14 +346,19 @@ func (pew *peWriter) fillSectionsInfo() error {
 	}
 
 	for i := range pew.h.sections {
+		if pew.h.sections[i].VirtualAddress+pew.h.sections[i].VirtualSize > pew.src.virtEnd {
+			pew.src.virtEnd = pew.h.sections[i].VirtualAddress + pew.h.sections[i].VirtualSize
+		}
+		if pew.h.sections[i].Characteristics&pe.IMAGE_SCN_CNT_UNINITIALIZED_DATA != 0 {
+			// Exclude sections containing uninitialized data from file offset
+			// calculations, as they do not occupy any data in the file.
+			continue
+		}
 		if pew.h.sections[i].PointerToRawData < pew.src.dataOffset {
 			pew.src.dataOffset = pew.h.sections[i].PointerToRawData
 		}
 		if pew.h.sections[i].PointerToRawData+pew.h.sections[i].SizeOfRawData > pew.src.dataEnd {
 			pew.src.dataEnd = pew.h.sections[i].PointerToRawData + pew.h.sections[i].SizeOfRawData
-		}
-		if pew.h.sections[i].VirtualAddress+pew.h.sections[i].VirtualSize > pew.src.virtEnd {
-			pew.src.virtEnd = pew.h.sections[i].VirtualAddress + pew.h.sections[i].VirtualSize
 		}
 	}
 	pew.src.virtEnd = pew.roundVirt(pew.src.virtEnd)


### PR DESCRIPTION
…in-file section sizes and offsets

These sections do not occupy space within the file.

Fixes https://github.com/tc-hib/winres/issues/2