### PR TITLE
Export language and string tables

### DIFF
--- a/version/binary.go
+++ b/version/binary.go
@@ -119,7 +119,7 @@ func (vi *Info) fixedFileInfo() _VS_FIXEDFILEINFO {
 	return ffi
 }
 
-func stringFileInfoBytes(lt *langTable) []byte {
+func stringFileInfoBytes(lt *LangTable) []byte {
 	buf := &bytes.Buffer{}
 	for _, langID := range lt.sortedKeys() {
 		b := stringTableBytes(langID, (*lt)[langID])
@@ -128,7 +128,7 @@ func stringFileInfoBytes(lt *langTable) []byte {
 	return nodeBytes(true, stringFileInfo, buf.Bytes(), 0)
 }
 
-func stringTableBytes(langID uint16, strings *stringTable) []byte {
+func stringTableBytes(langID uint16, strings *StringTable) []byte {
 	buf := &bytes.Buffer{}
 	for _, k := range strings.sortedKeys() {
 		b := stringBytes(k, (*strings)[k])
@@ -144,7 +144,7 @@ func stringBytes(key string, value string) []byte {
 	return nodeBytes(true, key, buf.Bytes(), len(wValue))
 }
 
-func varFileInfoBytes(lt *langTable) []byte {
+func varFileInfoBytes(lt *LangTable) []byte {
 	buf := &bytes.Buffer{}
 	var langs []uint32
 	for _, langID := range lt.sortedKeys() {
@@ -200,7 +200,7 @@ func writeStructAligned(buffer *bytes.Buffer, data interface{}) {
 	binary.Write(buffer, binary.LittleEndian, data)
 }
 
-func (st *stringTable) sortedKeys() []string {
+func (st *StringTable) sortedKeys() []string {
 	keys := make([]string, 0, len(*st))
 	for k := range *st {
 		keys = append(keys, k)
@@ -209,7 +209,7 @@ func (st *stringTable) sortedKeys() []string {
 	return keys
 }
 
-func (lt *langTable) sortedKeys() []uint16 {
+func (lt *LangTable) sortedKeys() []uint16 {
 	keys := make([]int, 0, len(*lt))
 	for k := range *lt {
 		keys = append(keys, int(k))

--- a/version/json.go
+++ b/version/json.go
@@ -17,7 +17,7 @@ type jsonFixed struct {
 
 type jsonVersionInfo struct {
 	Fixed *jsonFixed              `json:"fixed,omitempty"`
-	Info  map[string]*stringTable `json:"info,omitempty"`
+	Info  map[string]*StringTable `json:"info,omitempty"`
 }
 
 func (vi *Info) MarshalJSON() ([]byte, error) {
@@ -60,7 +60,7 @@ func (vi *Info) MarshalJSON() ([]byte, error) {
 		jvi.Fixed = &jf
 	}
 
-	jvi.Info = make(map[string]*stringTable)
+	jvi.Info = make(map[string]*StringTable)
 	for k, v := range vi.lt {
 		if v != nil {
 			jvi.Info[fmt.Sprintf("%04X", k)] = v
@@ -99,7 +99,7 @@ func (vi *Info) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	vi.lt = make(langTable)
+	vi.lt = make(LangTable)
 	for h, v := range jvi.Info {
 		var k uint16
 		_, err := fmt.Sscanf(h, "%X", &k)

--- a/version/json_test.go
+++ b/version/json_test.go
@@ -54,11 +54,11 @@ func TestInfo_MarshalJSON(t *testing.T) {
 	checkMarshal(t, vi, `{"fixed":{"type":"Unknown"},"info":{"0000":{"CompanyName":"Company name","ProductVersion":"Product version"},"0409":{"CompanyName":"Company name EN"},"040C":{"CompanyName":"Company name FR"}}}`)
 
 	vi.Type = 42
-	vi.lt = langTable{}
+	vi.lt = LangTable{}
 	checkMarshal(t, vi, `{"fixed":{"type":"Unknown"}}`)
 
 	vi.Type = App
-	vi.lt = make(langTable)
+	vi.lt = make(LangTable)
 	checkMarshal(t, vi, `{}`)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -50,7 +50,7 @@ type Info struct {
 	Flags          versionFlags
 	Type           fileType
 	Timestamp      time.Time
-	lt             langTable
+	lt             LangTable
 
 	// temporary state
 	pos int
@@ -65,9 +65,34 @@ type versionFlags struct {
 	SpecialBuild bool
 }
 
-type langTable map[uint16]*stringTable
+// LangTable holds different languages.
+type LangTable map[uint16]*StringTable
 
-type stringTable map[string]string
+// StringTable holds key/value metadata.
+type StringTable map[string]string
+
+// Table returns a copy of the language and containing string tables,
+// which hold key/value metadata.
+func (vi *Info) Table() LangTable {
+	if vi == nil || vi.lt == nil {
+		return nil
+	}
+
+	lt := make(LangTable, len(vi.lt))
+	for lang, langST := range vi.lt {
+		var st *StringTable
+		if langST != nil {
+			stm := make(StringTable, len(*langST))
+			for k, v := range *langST {
+				stm[k] = v
+			}
+			st = &stm
+		}
+		lt[lang] = st
+	}
+
+	return lt
+}
 
 // Set sets a key/value pair in the Info structure for a specific locale.
 //
@@ -80,7 +105,7 @@ type stringTable map[string]string
 // langID may also be 0 for neutral.
 func (vi *Info) Set(langID uint16, key string, value string) error {
 	if vi.lt == nil {
-		vi.lt = make(langTable)
+		vi.lt = make(LangTable)
 	}
 	if key == "" {
 		return errors.New(errEmptyKey)
@@ -93,7 +118,7 @@ func (vi *Info) Set(langID uint16, key string, value string) error {
 	}
 	st, ok := vi.lt[langID]
 	if !ok {
-		st = &stringTable{}
+		st = &StringTable{}
 		vi.lt[langID] = st
 	}
 	(*st)[key] = value
@@ -202,10 +227,10 @@ func MergeTranslations(translations map[uint16]*Info) *Info {
 	return vi
 }
 
-func (vi *Info) singleLang() *stringTable {
+func (vi *Info) singleLang() *StringTable {
 	var (
 		seen bool
-		lang *stringTable
+		lang *StringTable
 	)
 
 	for _, st := range vi.lt {

--- a/version/version.go
+++ b/version/version.go
@@ -336,3 +336,24 @@ func (vi *Info) splitLangs() map[uint16]*Info {
 
 	return m
 }
+
+// GetMainTranslation returns the main translation.
+func (lt LangTable) GetMainTranslation() StringTable {
+	main := lt[LangNeutral]
+	if main != nil {
+		return *main
+	}
+
+	main = lt[LangDefault]
+	if main != nil {
+		return *main
+	}
+
+	var lang uint16 = 0xFFFF
+	for k := range lt {
+		if k < lang {
+			lang = k
+		}
+	}
+	return *lt[lang]
+}


### PR DESCRIPTION
Hello,

Thanks for this great library!
I use it to get icons from exe's.

Additionally, I would like to get the product name too, but there is no way to get that information from outside the package.
So, I added and tested a simple function that returns a full copy of the language and string tables in order to not interfere with any already validated data in there.

Usually, I myself hate to get PRs with changes that were not discussed before - sorry about that if you feel the same way.
I am willing to make changes per your request.

Changes:
- Add Info.Table() to export tables
- Add LangTable.GetMainTranslation() to quickly get main translation
